### PR TITLE
Documentation added for checker tooling

### DIFF
--- a/check/find-corrupted-jpg.sh
+++ b/check/find-corrupted-jpg.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
+# find-corrupted-jpg.sh
+# Description: checks all jpg images in the given directory for corruption single-threadedly
+# Usage: ./find-corrupted-jpg.sh /PATH/TO/IMAGES
+# Expected output: 0 for valid images, 1 for corrupted ones, other numbers for errors
+# Dependencies: ImageMagick
 
-numcores=$(nproc --all)
-numcores=1
-if [ -z "$1" ]; then echo "please provide path to images to be checked" && exit 1; fi;
+if [ -z "$1" ]; then 
+    echo "please provide path to images to be checked"
+    exit 1
+fi
 
-find -L $1 -name '*.jpg' -type f| xargs -n 1 -P $numcores -I % sh -c 'identify -regard-warnings -verbose % > /dev/null 2>&1;echo % $?'
+# check jpg images for corruption. Only use one process at a time to avoid race conditions in the output
+find -L "$1" -name '*.jpg' -type f |
+    xargs -P 1 -I % sh -c '
+        identify -regard-warnings -verbose % > /dev/null 2>&1
+        echo % $?
+    '


### PR DESCRIPTION
(1) added a usage section at the top; 
(2) formatted the code for better readability; 
(3) (by Rutger) removed the numcores part; 
(4) (by Rutger) removed -n 1 from xargs to avoid warning (''xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value'').